### PR TITLE
Add HTTPRoute support to Helm chart

### DIFF
--- a/charts/nsi-dds/Chart.yaml
+++ b/charts/nsi-dds/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.17
+version: 1.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nsi-dds/templates/httproute.yaml
+++ b/charts/nsi-dds/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "nsi-dds.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "nsi-dds.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/nsi-dds/values.yaml
+++ b/charts/nsi-dds/values.yaml
@@ -79,6 +79,22 @@ ingress:
       hosts:
         - front.example.domain
 
+# Expose the service via gateway-api HTTPRoute instead of an Ingress.
+# Requires Gateway API CRDs and a suitable controller (e.g. Envoy Gateway).
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs:
+    - name: gateway
+      sectionName: http
+  hostnames:
+    - chart-example.local
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /dds
+
 # if you do not want to use ingress annotations to generate the Certificate manifest
 certificate:
   enabled: false


### PR DESCRIPTION
Adds helm template for HTTPRoute which can be used with the Gateway API instead of (nginx) ingresses. Placeholder variables are placed in values.yaml.